### PR TITLE
perf: improve performance of ZCAP capability creation

### DIFF
--- a/cmd/kms-rest/go.mod
+++ b/cmd/kms-rest/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/rs/cors v1.7.0
 	github.com/spf13/cobra v1.1.1
 	github.com/stretchr/testify v1.6.1
-	github.com/trustbloc/edge-core v0.1.5
+	github.com/trustbloc/edge-core v0.1.6-0.20210121114552-763e3f878b45
 	github.com/trustbloc/hub-kms v0.0.0-00010101000000-000000000000
 	go.opentelemetry.io/otel v0.15.0
 	go.opentelemetry.io/otel/exporters/trace/jaeger v0.15.0

--- a/cmd/kms-rest/go.sum
+++ b/cmd/kms-rest/go.sum
@@ -877,8 +877,8 @@ github.com/teserakt-io/golang-ed25519 v0.0.0-20200315192543-8255be791ce4/go.mod 
 github.com/tidwall/pretty v1.0.1/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/trustbloc/edge-core v0.1.5 h1:NWXBBZLjaFUi+fB/1nYfLmzip4VFLJ1b8saN1w7rj4M=
-github.com/trustbloc/edge-core v0.1.5/go.mod h1:YnXB2tOVOcW+zK5Xs9RZLhWSGujUzSeZUXrwDOouPgA=
+github.com/trustbloc/edge-core v0.1.6-0.20210121114552-763e3f878b45 h1:Ie+4nJYQLs1Xrm3AOEXPlHpiHa88YV04PidlZYm5gYY=
+github.com/trustbloc/edge-core v0.1.6-0.20210121114552-763e3f878b45/go.mod h1:YnXB2tOVOcW+zK5Xs9RZLhWSGujUzSeZUXrwDOouPgA=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/cmd/kms-rest/startcmd/lddocument_loader.go
+++ b/cmd/kms-rest/startcmd/lddocument_loader.go
@@ -125,6 +125,71 @@ const (
   }]
 }
 `
+
+	trustblocCredentialsV1 = `{
+  "@context": {
+    "@version": 1.1,
+    "id": "@id",
+    "type": "@type",
+    "trustbloc": "https://trustbloc.github.io/context#",
+    "ldssk": "https://w3c-ccg.github.io/lds-jws2020/contexts/#",
+    "sec": "https://w3id.org/security#",
+    "publicKeyJwk": {
+      "@id": "sec:publicKeyJwk",
+      "@type": "@json"
+    },
+    "JsonWebSignature2020": {
+      "@id": "https://w3c-ccg.github.io/lds-jws2020/contexts/#JsonWebSignature2020",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "sec": "https://w3id.org/security#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "challenge": "sec:challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "xsd:dateTime"
+        },
+        "domain": "sec:domain",
+        "expires": {
+          "@id": "sec:expiration",
+          "@type": "xsd:dateTime"
+        },
+        "jws": "sec:jws",
+        "nonce": "sec:nonce",
+        "proofPurpose": {
+          "@id": "sec:proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "sec": "https://w3id.org/security#",
+            "assertionMethod": {
+              "@id": "sec:assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "sec:authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            }
+          }
+        },
+        "proofValue": "sec:proofValue",
+        "verificationMethod": {
+          "@id": "sec:verificationMethod",
+          "@type": "@id"
+        }
+      }
+    }
+  }
+}
+`
 )
 
 func loadLDContext() (map[string]*ld.RemoteDocument, error) {
@@ -139,6 +204,10 @@ func loadLDContext() (map[string]*ld.RemoteDocument, error) {
 		{
 			vocab:   "https://w3id.org/security/v2",
 			content: w3idOrgSecurityV2,
+		},
+		{
+			vocab:   "https://trustbloc.github.io/context/vc/credentials-v1.jsonld",
+			content: trustblocCredentialsV1,
 		},
 	}
 

--- a/cmd/kms-rest/startcmd/start.go
+++ b/cmd/kms-rest/startcmd/start.go
@@ -618,7 +618,7 @@ func getKeyManagerStorageParameters(cmd *cobra.Command) (*storageParameters, err
 	}, nil
 }
 
-func startKmsService(params *kmsRestParameters, srv Server) error {
+func startKmsService(params *kmsRestParameters, srv Server) error { //nolint:funlen TODO: refactor
 	if params.logLevel != "" {
 		setLogLevel(params.logLevel, srv)
 	}
@@ -650,7 +650,10 @@ func startKmsService(params *kmsRestParameters, srv Server) error {
 
 	kmsRouter := router.PathPrefix(operation.KMSBasePath).Subrouter()
 
-	kmsREST := operation.New(config)
+	kmsREST, err := operation.New(config)
+	if err != nil {
+		return fmt.Errorf("start KMS service: %w", err)
+	}
 
 	if params.enableZCAPs {
 		kmsRouter.Use(kmsREST.ZCAPLDMiddleware)

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/piprate/json-gold v0.3.1-0.20201222165305-f4ce31c02ca3
 	github.com/rs/xid v1.2.1
 	github.com/stretchr/testify v1.6.1
-	github.com/trustbloc/edge-core v0.1.5
+	github.com/trustbloc/edge-core v0.1.6-0.20210121114552-763e3f878b45
 	go.opentelemetry.io/otel v0.15.0
 	golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb
 )

--- a/go.sum
+++ b/go.sum
@@ -807,8 +807,8 @@ github.com/teserakt-io/golang-ed25519 v0.0.0-20200315192543-8255be791ce4/go.mod 
 github.com/tidwall/pretty v1.0.1/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/trustbloc/edge-core v0.1.5 h1:NWXBBZLjaFUi+fB/1nYfLmzip4VFLJ1b8saN1w7rj4M=
-github.com/trustbloc/edge-core v0.1.5/go.mod h1:YnXB2tOVOcW+zK5Xs9RZLhWSGujUzSeZUXrwDOouPgA=
+github.com/trustbloc/edge-core v0.1.6-0.20210121114552-763e3f878b45 h1:Ie+4nJYQLs1Xrm3AOEXPlHpiHa88YV04PidlZYm5gYY=
+github.com/trustbloc/edge-core v0.1.6-0.20210121114552-763e3f878b45/go.mod h1:YnXB2tOVOcW+zK5Xs9RZLhWSGujUzSeZUXrwDOouPgA=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/pkg/restapi/kms/operation/middleware_test.go
+++ b/pkg/restapi/kms/operation/middleware_test.go
@@ -25,7 +25,8 @@ import (
 
 func TestMiddleware(t *testing.T) {
 	t.Run("returns middleware", func(t *testing.T) {
-		o := New(newConfig())
+		o, err := New(newConfig())
+		require.NoError(t, err)
 		require.NotEmpty(t, o.ZCAPLDMiddleware(nil))
 	})
 
@@ -33,7 +34,11 @@ func TestMiddleware(t *testing.T) {
 		t.Run("protects /keystore endpoint", func(t *testing.T) {
 			handler := &handler{}
 			result := httptest.NewRecorder()
-			mw := New(newConfig()).ZCAPLDMiddleware(handler)
+
+			o, err := New(newConfig())
+			require.NoError(t, err)
+
+			mw := o.ZCAPLDMiddleware(handler)
 			require.IsType(t, &mwHandler{}, mw)
 			(mw).(*mwHandler).routeFunc = mockRouteFunc(&mockNamer{name: keystoresEndpoint})
 			mw.ServeHTTP(
@@ -47,7 +52,11 @@ func TestMiddleware(t *testing.T) {
 	t.Run("authz: zcaps", func(t *testing.T) {
 		t.Run("protects endpoints", func(t *testing.T) {
 			handler := &handler{}
-			mw := New(newConfig()).ZCAPLDMiddleware(handler)
+
+			o, err := New(newConfig())
+			require.NoError(t, err)
+
+			mw := o.ZCAPLDMiddleware(handler)
 			require.IsType(t, &mwHandler{}, mw)
 			(mw).(*mwHandler).routeFunc = func(r *http.Request) namer {
 				return &mockNamer{name: r.URL.Path}
@@ -80,7 +89,11 @@ func TestMiddleware(t *testing.T) {
 
 		t.Run("protects endpoints", func(t *testing.T) {
 			handler := &handler{}
-			mw := New(newConfig()).ZCAPLDMiddleware(handler)
+
+			o, err := New(newConfig())
+			require.NoError(t, err)
+
+			mw := o.ZCAPLDMiddleware(handler)
 			require.IsType(t, &mwHandler{}, mw)
 			(mw).(*mwHandler).routeFunc = func(r *http.Request) namer {
 				return &mockNamer{name: r.URL.Path}
@@ -114,7 +127,11 @@ func TestMiddleware(t *testing.T) {
 
 		t.Run("badrequest if endpoint is not valid", func(t *testing.T) {
 			handler := &handler{}
-			mw := New(newConfig()).ZCAPLDMiddleware(handler)
+
+			o, err := New(newConfig())
+			require.NoError(t, err)
+
+			mw := o.ZCAPLDMiddleware(handler)
 			require.IsType(t, &mwHandler{}, mw)
 			(mw).(*mwHandler).routeFunc = func(r *http.Request) namer {
 				return &mockNamer{name: r.URL.Path}

--- a/pkg/restapi/kms/operation/operations_cryptobox_test.go
+++ b/pkg/restapi/kms/operation/operations_cryptobox_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	mockkms "github.com/trustbloc/hub-kms/pkg/internal/mock/kms"
-	"github.com/trustbloc/hub-kms/pkg/restapi/kms/operation"
 )
 
 const (
@@ -32,7 +31,7 @@ const (
 func TestEasyHandler(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		cb := &mockCryptoBox{EasyValue: []byte("cipher text")}
-		op := operation.New(newConfig(withCryptoBox(cb)))
+		op := newOperation(t, newConfig(withCryptoBox(cb)))
 		handler := getHandler(t, op, easyEndpoint, http.MethodPost)
 
 		payload := base64.URLEncoding.EncodeToString([]byte("payload"))
@@ -52,7 +51,7 @@ func TestEasyHandler(t *testing.T) {
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "", bytes.NewBuffer([]byte("")))
 		require.NoError(t, err)
 
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, easyEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -63,7 +62,7 @@ func TestEasyHandler(t *testing.T) {
 	})
 
 	t.Run("Received bad request: bad encoded payload", func(t *testing.T) {
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, easyEndpoint, http.MethodPost)
 
 		nonce := base64.URLEncoding.EncodeToString([]byte("nonce"))
@@ -79,7 +78,7 @@ func TestEasyHandler(t *testing.T) {
 	})
 
 	t.Run("Received bad request: bad encoded nonce", func(t *testing.T) {
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, easyEndpoint, http.MethodPost)
 
 		payload := base64.URLEncoding.EncodeToString([]byte("payload"))
@@ -95,7 +94,7 @@ func TestEasyHandler(t *testing.T) {
 	})
 
 	t.Run("Received bad request: bad encoded theirPub", func(t *testing.T) {
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, easyEndpoint, http.MethodPost)
 
 		payload := base64.URLEncoding.EncodeToString([]byte("payload"))
@@ -113,7 +112,7 @@ func TestEasyHandler(t *testing.T) {
 	t.Run("Failed to resolve a keystore", func(t *testing.T) {
 		svc := &mockkms.MockService{ResolveKeystoreErr: errors.New("resolve keystore error")}
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, easyEndpoint, http.MethodPost)
 
 		payload := base64.URLEncoding.EncodeToString([]byte("payload"))
@@ -130,7 +129,7 @@ func TestEasyHandler(t *testing.T) {
 	})
 
 	t.Run("Failed to create a CryptoBox instance", func(t *testing.T) {
-		op := operation.New(newConfig(withCryptoBoxCreatorErr(errors.New("creator error"))))
+		op := newOperation(t, newConfig(withCryptoBoxCreatorErr(errors.New("creator error"))))
 		handler := getHandler(t, op, easyEndpoint, http.MethodPost)
 
 		payload := base64.URLEncoding.EncodeToString([]byte("payload"))
@@ -148,7 +147,7 @@ func TestEasyHandler(t *testing.T) {
 
 	t.Run("Failed to easy a message", func(t *testing.T) {
 		cb := &mockCryptoBox{EasyErr: errors.New("easy error")}
-		op := operation.New(newConfig(withCryptoBox(cb)))
+		op := newOperation(t, newConfig(withCryptoBox(cb)))
 		handler := getHandler(t, op, easyEndpoint, http.MethodPost)
 
 		payload := base64.URLEncoding.EncodeToString([]byte("payload"))
@@ -168,7 +167,7 @@ func TestEasyHandler(t *testing.T) {
 func TestEasyOpenHandler(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		cb := &mockCryptoBox{EasyOpenValue: []byte("plain text")}
-		op := operation.New(newConfig(withCryptoBox(cb)))
+		op := newOperation(t, newConfig(withCryptoBox(cb)))
 		handler := getHandler(t, op, easyOpenEndpoint, http.MethodPost)
 
 		cipherText := base64.URLEncoding.EncodeToString([]byte("cipher text"))
@@ -189,7 +188,7 @@ func TestEasyOpenHandler(t *testing.T) {
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "", bytes.NewBuffer([]byte("")))
 		require.NoError(t, err)
 
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, easyOpenEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -200,7 +199,7 @@ func TestEasyOpenHandler(t *testing.T) {
 	})
 
 	t.Run("Received bad request: bad encoded cipherText", func(t *testing.T) {
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, easyOpenEndpoint, http.MethodPost)
 
 		nonce := base64.URLEncoding.EncodeToString([]byte("nonce"))
@@ -217,7 +216,7 @@ func TestEasyOpenHandler(t *testing.T) {
 	})
 
 	t.Run("Received bad request: bad encoded nonce", func(t *testing.T) {
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, easyOpenEndpoint, http.MethodPost)
 
 		cipherText := base64.URLEncoding.EncodeToString([]byte("cipher text"))
@@ -234,7 +233,7 @@ func TestEasyOpenHandler(t *testing.T) {
 	})
 
 	t.Run("Received bad request: bad encoded theirPub", func(t *testing.T) {
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, easyOpenEndpoint, http.MethodPost)
 
 		cipherText := base64.URLEncoding.EncodeToString([]byte("cipher text"))
@@ -251,7 +250,7 @@ func TestEasyOpenHandler(t *testing.T) {
 	})
 
 	t.Run("Received bad request: bad encoded myPub", func(t *testing.T) {
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, easyOpenEndpoint, http.MethodPost)
 
 		cipherText := base64.URLEncoding.EncodeToString([]byte("cipher text"))
@@ -270,7 +269,7 @@ func TestEasyOpenHandler(t *testing.T) {
 	t.Run("Failed to resolve a keystore", func(t *testing.T) {
 		svc := &mockkms.MockService{ResolveKeystoreErr: errors.New("resolve keystore error")}
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, easyOpenEndpoint, http.MethodPost)
 
 		cipherText := base64.URLEncoding.EncodeToString([]byte("cipher text"))
@@ -288,7 +287,7 @@ func TestEasyOpenHandler(t *testing.T) {
 	})
 
 	t.Run("Failed to create a CryptoBox instance", func(t *testing.T) {
-		op := operation.New(newConfig(withCryptoBoxCreatorErr(errors.New("creator error"))))
+		op := newOperation(t, newConfig(withCryptoBoxCreatorErr(errors.New("creator error"))))
 		handler := getHandler(t, op, easyOpenEndpoint, http.MethodPost)
 
 		cipherText := base64.URLEncoding.EncodeToString([]byte("cipher text"))
@@ -307,7 +306,7 @@ func TestEasyOpenHandler(t *testing.T) {
 
 	t.Run("Failed to easy open a message", func(t *testing.T) {
 		cb := &mockCryptoBox{EasyOpenErr: errors.New("easy open error")}
-		op := operation.New(newConfig(withCryptoBox(cb)))
+		op := newOperation(t, newConfig(withCryptoBox(cb)))
 		handler := getHandler(t, op, easyOpenEndpoint, http.MethodPost)
 
 		cipherText := base64.URLEncoding.EncodeToString([]byte("cipher text"))
@@ -328,7 +327,7 @@ func TestEasyOpenHandler(t *testing.T) {
 func TestSealOpenHandler(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		cb := &mockCryptoBox{SealOpenValue: []byte("plain text")}
-		op := operation.New(newConfig(withCryptoBox(cb)))
+		op := newOperation(t, newConfig(withCryptoBox(cb)))
 		handler := getHandler(t, op, sealOpenEndpoint, http.MethodPost)
 
 		cipherText := base64.URLEncoding.EncodeToString([]byte("cipher text"))
@@ -347,7 +346,7 @@ func TestSealOpenHandler(t *testing.T) {
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "", bytes.NewBuffer([]byte("")))
 		require.NoError(t, err)
 
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, sealOpenEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -358,7 +357,7 @@ func TestSealOpenHandler(t *testing.T) {
 	})
 
 	t.Run("Received bad request: bad encoded cipherText", func(t *testing.T) {
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, sealOpenEndpoint, http.MethodPost)
 
 		myPub := base64.URLEncoding.EncodeToString([]byte("my pub"))
@@ -373,7 +372,7 @@ func TestSealOpenHandler(t *testing.T) {
 	})
 
 	t.Run("Received bad request: bad encoded myPub", func(t *testing.T) {
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, sealOpenEndpoint, http.MethodPost)
 
 		cipherText := base64.URLEncoding.EncodeToString([]byte("cipher text"))
@@ -390,7 +389,7 @@ func TestSealOpenHandler(t *testing.T) {
 	t.Run("Failed to resolve a keystore", func(t *testing.T) {
 		svc := &mockkms.MockService{ResolveKeystoreErr: errors.New("resolve keystore error")}
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, sealOpenEndpoint, http.MethodPost)
 
 		cipherText := base64.URLEncoding.EncodeToString([]byte("cipher text"))
@@ -406,7 +405,7 @@ func TestSealOpenHandler(t *testing.T) {
 	})
 
 	t.Run("Failed to create a CryptoBox instance", func(t *testing.T) {
-		op := operation.New(newConfig(withCryptoBoxCreatorErr(errors.New("creator error"))))
+		op := newOperation(t, newConfig(withCryptoBoxCreatorErr(errors.New("creator error"))))
 		handler := getHandler(t, op, sealOpenEndpoint, http.MethodPost)
 
 		cipherText := base64.URLEncoding.EncodeToString([]byte("cipher text"))
@@ -423,7 +422,7 @@ func TestSealOpenHandler(t *testing.T) {
 
 	t.Run("Failed to seal open a payload", func(t *testing.T) {
 		cb := &mockCryptoBox{SealOpenErr: errors.New("seal open error")}
-		op := operation.New(newConfig(withCryptoBox(cb)))
+		op := newOperation(t, newConfig(withCryptoBox(cb)))
 		handler := getHandler(t, op, sealOpenEndpoint, http.MethodPost)
 
 		cipherText := base64.URLEncoding.EncodeToString([]byte("cipher text"))

--- a/pkg/restapi/kms/operation/operations_test.go
+++ b/pkg/restapi/kms/operation/operations_test.go
@@ -143,13 +143,13 @@ const (
 )
 
 func TestNew(t *testing.T) {
-	op := operation.New(newConfig())
+	op := newOperation(t, newConfig())
 	require.NotNil(t, op)
 }
 
 func TestCreateKeystoreHandler(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, keystoresEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -164,7 +164,7 @@ func TestCreateKeystoreHandler(t *testing.T) {
 			return "", fmt.Errorf("failed to create did key")
 		}}
 
-		op := operation.New(newConfig(withAuthService(svc)))
+		op := newOperation(t, newConfig(withAuthService(svc)))
 		handler := getHandler(t, op, keystoresEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -178,7 +178,7 @@ func TestCreateKeystoreHandler(t *testing.T) {
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "", bytes.NewBuffer([]byte("")))
 		require.NoError(t, err)
 
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, keystoresEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -191,7 +191,7 @@ func TestCreateKeystoreHandler(t *testing.T) {
 	t.Run("Failed to create a keystore", func(t *testing.T) {
 		svc := &mockkms.MockService{CreateKeystoreErr: errors.New("create keystore error")}
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, keystoresEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -204,7 +204,7 @@ func TestCreateKeystoreHandler(t *testing.T) {
 	t.Run("internal server error if cannot create zcap", func(t *testing.T) {
 		svc := &mockAuthService{newCapabilityErr: errors.New("test")}
 
-		op := operation.New(newConfig(withAuthService(svc)))
+		op := newOperation(t, newConfig(withAuthService(svc)))
 		handler := getHandler(t, op, keystoresEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -217,7 +217,7 @@ func TestCreateKeystoreHandler(t *testing.T) {
 
 func TestUpdateCapabilityHandler(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, capabilityEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -230,7 +230,7 @@ func TestUpdateCapabilityHandler(t *testing.T) {
 		svc := mockKMSService()
 		svc.GetKeystoreDataErr = errors.New("get keystore data error")
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, capabilityEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -244,7 +244,7 @@ func TestUpdateCapabilityHandler(t *testing.T) {
 		svc := mockKMSService()
 		svc.SaveKeystoreDataErr = errors.New("save keystore data error")
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, capabilityEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -255,7 +255,7 @@ func TestUpdateCapabilityHandler(t *testing.T) {
 	})
 
 	t.Run("test empty capability", func(t *testing.T) {
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, capabilityEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -268,7 +268,7 @@ func TestUpdateCapabilityHandler(t *testing.T) {
 
 func TestCreateKeyHandler(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, keysEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -282,7 +282,7 @@ func TestCreateKeyHandler(t *testing.T) {
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "", bytes.NewBuffer([]byte("")))
 		require.NoError(t, err)
 
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, keysEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -295,7 +295,7 @@ func TestCreateKeyHandler(t *testing.T) {
 	t.Run("Failed to resolve a keystore", func(t *testing.T) {
 		svc := &mockkms.MockService{ResolveKeystoreErr: errors.New("resolve keystore error")}
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, keysEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -309,7 +309,7 @@ func TestCreateKeyHandler(t *testing.T) {
 		svc := &mockkms.MockService{}
 		svc.ResolveKeystoreValue = &keystore.MockKeystore{CreateKeyErr: errors.New("create key error")}
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, keysEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -325,7 +325,7 @@ func TestExportKeyHandler(t *testing.T) {
 		svc := mockKMSService()
 		svc.ResolveKeystoreValue = &keystore.MockKeystore{ExportKeyValue: []byte("public key bytes")}
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, exportEndpoint, http.MethodGet)
 
 		rr := httptest.NewRecorder()
@@ -338,7 +338,7 @@ func TestExportKeyHandler(t *testing.T) {
 	t.Run("Failed to resolve a keystore", func(t *testing.T) {
 		svc := &mockkms.MockService{ResolveKeystoreErr: errors.New("resolve keystore error")}
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, exportEndpoint, http.MethodGet)
 
 		rr := httptest.NewRecorder()
@@ -352,7 +352,7 @@ func TestExportKeyHandler(t *testing.T) {
 		svc := mockKMSService()
 		svc.ResolveKeystoreValue = &keystore.MockKeystore{ExportKeyErr: errors.New("export key error")}
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, exportEndpoint, http.MethodGet)
 
 		rr := httptest.NewRecorder()
@@ -368,7 +368,7 @@ func TestSignHandler(t *testing.T) {
 		svc := mockKMSService()
 		svc.SignValue = []byte("signature")
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, signEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -382,7 +382,7 @@ func TestSignHandler(t *testing.T) {
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "", bytes.NewBuffer([]byte("")))
 		require.NoError(t, err)
 
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, signEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -393,7 +393,7 @@ func TestSignHandler(t *testing.T) {
 	})
 
 	t.Run("Received bad request: bad encoded message", func(t *testing.T) {
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, signEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -406,7 +406,7 @@ func TestSignHandler(t *testing.T) {
 	t.Run("Failed to resolve a keystore", func(t *testing.T) {
 		svc := &mockkms.MockService{ResolveKeystoreErr: errors.New("resolve keystore error")}
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, signEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -420,7 +420,7 @@ func TestSignHandler(t *testing.T) {
 		svc := mockKMSService()
 		svc.ResolveKeystoreValue = &keystore.MockKeystore{GetKeyHandleErr: errors.New("get key handle error")}
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, signEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -434,7 +434,7 @@ func TestSignHandler(t *testing.T) {
 		svc := mockKMSService()
 		svc.SignErr = errors.New("sign error")
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, signEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -447,7 +447,7 @@ func TestSignHandler(t *testing.T) {
 
 func TestVerifyHandler(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, verifyEndpoint, http.MethodPost)
 
 		sig := base64.URLEncoding.EncodeToString([]byte("test signature"))
@@ -464,7 +464,7 @@ func TestVerifyHandler(t *testing.T) {
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "", bytes.NewBuffer([]byte("")))
 		require.NoError(t, err)
 
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, verifyEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -475,7 +475,7 @@ func TestVerifyHandler(t *testing.T) {
 	})
 
 	t.Run("Received bad request: bad encoded signature", func(t *testing.T) {
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, verifyEndpoint, http.MethodPost)
 
 		msg := base64.URLEncoding.EncodeToString([]byte("test message"))
@@ -489,7 +489,7 @@ func TestVerifyHandler(t *testing.T) {
 	})
 
 	t.Run("Received bad request: bad encoded message", func(t *testing.T) {
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, verifyEndpoint, http.MethodPost)
 
 		sig := base64.URLEncoding.EncodeToString([]byte("test signature"))
@@ -505,7 +505,7 @@ func TestVerifyHandler(t *testing.T) {
 	t.Run("Failed to resolve a keystore", func(t *testing.T) {
 		svc := &mockkms.MockService{ResolveKeystoreErr: errors.New("resolve keystore error")}
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, verifyEndpoint, http.MethodPost)
 
 		sig := base64.URLEncoding.EncodeToString([]byte("test signature"))
@@ -523,7 +523,7 @@ func TestVerifyHandler(t *testing.T) {
 		svc := mockKMSService()
 		svc.ResolveKeystoreValue = &keystore.MockKeystore{GetKeyHandleErr: errors.New("get key handle error")}
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, verifyEndpoint, http.MethodPost)
 
 		sig := base64.URLEncoding.EncodeToString([]byte("test signature"))
@@ -541,7 +541,7 @@ func TestVerifyHandler(t *testing.T) {
 		svc := mockKMSService()
 		svc.VerifyErr = errors.New("verify error")
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, verifyEndpoint, http.MethodPost)
 
 		sig := base64.URLEncoding.EncodeToString([]byte("test signature"))
@@ -561,7 +561,7 @@ func TestEncryptHandler(t *testing.T) {
 		svc := mockKMSService()
 		svc.EncryptValue = []byte("cipher text")
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, encryptEndpoint, http.MethodPost)
 
 		msg := base64.URLEncoding.EncodeToString([]byte("test message"))
@@ -579,7 +579,7 @@ func TestEncryptHandler(t *testing.T) {
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "", bytes.NewBuffer([]byte("")))
 		require.NoError(t, err)
 
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, encryptEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -590,7 +590,7 @@ func TestEncryptHandler(t *testing.T) {
 	})
 
 	t.Run("Received bad request: bad encoded message", func(t *testing.T) {
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, encryptEndpoint, http.MethodPost)
 
 		aad := base64.URLEncoding.EncodeToString([]byte("additional data"))
@@ -604,7 +604,7 @@ func TestEncryptHandler(t *testing.T) {
 	})
 
 	t.Run("Received bad request: bad encoded aad", func(t *testing.T) {
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, encryptEndpoint, http.MethodPost)
 
 		msg := base64.URLEncoding.EncodeToString([]byte("test message"))
@@ -620,7 +620,7 @@ func TestEncryptHandler(t *testing.T) {
 	t.Run("Failed to resolve a keystore", func(t *testing.T) {
 		svc := &mockkms.MockService{ResolveKeystoreErr: errors.New("resolve keystore error")}
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, encryptEndpoint, http.MethodPost)
 
 		msg := base64.URLEncoding.EncodeToString([]byte("test message"))
@@ -638,7 +638,7 @@ func TestEncryptHandler(t *testing.T) {
 		svc := mockKMSService()
 		svc.ResolveKeystoreValue = &keystore.MockKeystore{GetKeyHandleErr: errors.New("get key handle error")}
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, encryptEndpoint, http.MethodPost)
 
 		msg := base64.URLEncoding.EncodeToString([]byte("test message"))
@@ -656,7 +656,7 @@ func TestEncryptHandler(t *testing.T) {
 		svc := mockKMSService()
 		svc.EncryptErr = errors.New("encrypt error")
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, encryptEndpoint, http.MethodPost)
 
 		msg := base64.URLEncoding.EncodeToString([]byte("test message"))
@@ -676,7 +676,7 @@ func TestDecryptHandler(t *testing.T) {
 		svc := mockKMSService()
 		svc.DecryptValue = []byte("plain text")
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, decryptEndpoint, http.MethodPost)
 
 		cipherText := base64.URLEncoding.EncodeToString([]byte("test cipher text"))
@@ -695,7 +695,7 @@ func TestDecryptHandler(t *testing.T) {
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "", bytes.NewBuffer([]byte("")))
 		require.NoError(t, err)
 
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, decryptEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -706,7 +706,7 @@ func TestDecryptHandler(t *testing.T) {
 	})
 
 	t.Run("Received bad request: bad encoded cipher text", func(t *testing.T) {
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, decryptEndpoint, http.MethodPost)
 
 		aad := base64.URLEncoding.EncodeToString([]byte("additional data"))
@@ -721,7 +721,7 @@ func TestDecryptHandler(t *testing.T) {
 	})
 
 	t.Run("Received bad request: bad encoded aad", func(t *testing.T) {
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, decryptEndpoint, http.MethodPost)
 
 		cipherText := base64.URLEncoding.EncodeToString([]byte("test cipher text"))
@@ -736,7 +736,7 @@ func TestDecryptHandler(t *testing.T) {
 	})
 
 	t.Run("Received bad request: bad encoded nonce", func(t *testing.T) {
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, decryptEndpoint, http.MethodPost)
 
 		cipherText := base64.URLEncoding.EncodeToString([]byte("test cipher text"))
@@ -753,7 +753,7 @@ func TestDecryptHandler(t *testing.T) {
 	t.Run("Failed to resolve a keystore", func(t *testing.T) {
 		svc := &mockkms.MockService{ResolveKeystoreErr: errors.New("resolve keystore error")}
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, decryptEndpoint, http.MethodPost)
 
 		cipherText := base64.URLEncoding.EncodeToString([]byte("test cipher text"))
@@ -772,7 +772,7 @@ func TestDecryptHandler(t *testing.T) {
 		svc := mockKMSService()
 		svc.ResolveKeystoreValue = &keystore.MockKeystore{GetKeyHandleErr: errors.New("get key handle error")}
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, decryptEndpoint, http.MethodPost)
 
 		cipherText := base64.URLEncoding.EncodeToString([]byte("test cipher text"))
@@ -791,7 +791,7 @@ func TestDecryptHandler(t *testing.T) {
 		svc := mockKMSService()
 		svc.DecryptErr = errors.New("decrypt error")
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, decryptEndpoint, http.MethodPost)
 
 		cipherText := base64.URLEncoding.EncodeToString([]byte("test cipher text"))
@@ -812,7 +812,7 @@ func TestComputeMACHandler(t *testing.T) {
 		svc := mockKMSService()
 		svc.ComputeMACValue = []byte("mac")
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, computeMACEndpoint, http.MethodPost)
 
 		data := base64.URLEncoding.EncodeToString([]byte("test data"))
@@ -829,7 +829,7 @@ func TestComputeMACHandler(t *testing.T) {
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "", bytes.NewBuffer([]byte("")))
 		require.NoError(t, err)
 
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, computeMACEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -840,7 +840,7 @@ func TestComputeMACHandler(t *testing.T) {
 	})
 
 	t.Run("Received bad request: bad encoded data", func(t *testing.T) {
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, computeMACEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -853,7 +853,7 @@ func TestComputeMACHandler(t *testing.T) {
 	t.Run("Failed to resolve a keystore", func(t *testing.T) {
 		svc := &mockkms.MockService{ResolveKeystoreErr: errors.New("resolve keystore error")}
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, computeMACEndpoint, http.MethodPost)
 
 		data := base64.URLEncoding.EncodeToString([]byte("test data"))
@@ -870,7 +870,7 @@ func TestComputeMACHandler(t *testing.T) {
 		svc := mockKMSService()
 		svc.ResolveKeystoreValue = &keystore.MockKeystore{GetKeyHandleErr: errors.New("get key handle error")}
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, computeMACEndpoint, http.MethodPost)
 
 		data := base64.URLEncoding.EncodeToString([]byte("test data"))
@@ -887,7 +887,7 @@ func TestComputeMACHandler(t *testing.T) {
 		svc := mockKMSService()
 		svc.ComputeMACErr = errors.New("compute mac error")
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, computeMACEndpoint, http.MethodPost)
 
 		data := base64.URLEncoding.EncodeToString([]byte("test data"))
@@ -906,7 +906,7 @@ func TestVerifyMACHandler(t *testing.T) {
 		svc := mockKMSService()
 		svc.ComputeMACValue = []byte("mac")
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, verifyMACEndpoint, http.MethodPost)
 
 		mac := base64.URLEncoding.EncodeToString([]byte("mac"))
@@ -923,7 +923,7 @@ func TestVerifyMACHandler(t *testing.T) {
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "", bytes.NewBuffer([]byte("")))
 		require.NoError(t, err)
 
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, verifyMACEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -934,7 +934,7 @@ func TestVerifyMACHandler(t *testing.T) {
 	})
 
 	t.Run("Received bad request: bad encoded mac", func(t *testing.T) {
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, verifyMACEndpoint, http.MethodPost)
 
 		data := base64.URLEncoding.EncodeToString([]byte("test data"))
@@ -948,7 +948,7 @@ func TestVerifyMACHandler(t *testing.T) {
 	})
 
 	t.Run("Received bad request: bad encoded data", func(t *testing.T) {
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, verifyMACEndpoint, http.MethodPost)
 
 		mac := base64.URLEncoding.EncodeToString([]byte("mac"))
@@ -964,7 +964,7 @@ func TestVerifyMACHandler(t *testing.T) {
 	t.Run("Failed to resolve a keystore", func(t *testing.T) {
 		svc := &mockkms.MockService{ResolveKeystoreErr: errors.New("resolve keystore error")}
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, verifyMACEndpoint, http.MethodPost)
 
 		mac := base64.URLEncoding.EncodeToString([]byte("mac"))
@@ -982,7 +982,7 @@ func TestVerifyMACHandler(t *testing.T) {
 		svc := mockKMSService()
 		svc.ResolveKeystoreValue = &keystore.MockKeystore{GetKeyHandleErr: errors.New("get key handle error")}
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, verifyMACEndpoint, http.MethodPost)
 
 		mac := base64.URLEncoding.EncodeToString([]byte("mac"))
@@ -1000,7 +1000,7 @@ func TestVerifyMACHandler(t *testing.T) {
 		svc := mockKMSService()
 		svc.VerifyMACErr = errors.New("verify mac error")
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, verifyMACEndpoint, http.MethodPost)
 
 		mac := base64.URLEncoding.EncodeToString([]byte("mac"))
@@ -1026,7 +1026,7 @@ func (failingResponseWriter) Write(_ []byte) (int, error) {
 func TestFailToWriteResponse(t *testing.T) {
 	logger := &mocklogger.MockLogger{}
 
-	op := operation.New(newConfig(withLogger(logger)))
+	op := newOperation(t, newConfig(withLogger(logger)))
 	handler := getHandler(t, op, signEndpoint, http.MethodPost)
 	req := buildSignReq(t, base64.URLEncoding.EncodeToString([]byte("test message")))
 
@@ -1041,7 +1041,7 @@ func TestFailToWriteErrorResponse(t *testing.T) {
 	svc := &mockkms.MockService{ResolveKeystoreErr: errors.New("resolve keystore error")}
 	logger := &mocklogger.MockLogger{}
 
-	op := operation.New(newConfig(withKMSService(svc), withLogger(logger)))
+	op := newOperation(t, newConfig(withKMSService(svc), withLogger(logger)))
 	handler := getHandler(t, op, keysEndpoint, http.MethodPost)
 	req := buildCreateKeyReq(t)
 
@@ -1050,6 +1050,15 @@ func TestFailToWriteErrorResponse(t *testing.T) {
 
 	require.Empty(t, rr.Body.String())
 	require.Contains(t, logger.ErrorLogContents, "Unable to send an error message")
+}
+
+func newOperation(t *testing.T, c *operation.Config) *operation.Operation {
+	t.Helper()
+
+	op, err := operation.New(c)
+	require.NoError(t, err)
+
+	return op
 }
 
 func getHandler(t *testing.T, op *operation.Operation, pathToLookup, methodToLookup string) operation.Handler {

--- a/pkg/restapi/kms/operation/operations_unwrap_test.go
+++ b/pkg/restapi/kms/operation/operations_unwrap_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/trustbloc/hub-kms/pkg/internal/mock/keystore"
 	mockkms "github.com/trustbloc/hub-kms/pkg/internal/mock/kms"
-	"github.com/trustbloc/hub-kms/pkg/restapi/kms/operation"
 )
 
 func TestUnwrapHandler(t *testing.T) {
@@ -30,7 +29,7 @@ func TestUnwrapHandler(t *testing.T) {
 		svc := mockKMSService()
 		svc.UnwrapValue = []byte("unwrap key value")
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, unwrapEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -44,7 +43,7 @@ func TestUnwrapHandler(t *testing.T) {
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "", bytes.NewBuffer([]byte("")))
 		require.NoError(t, err)
 
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, unwrapEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -57,7 +56,7 @@ func TestUnwrapHandler(t *testing.T) {
 	t.Run("Failed to resolve a keystore", func(t *testing.T) {
 		svc := &mockkms.MockService{ResolveKeystoreErr: errors.New("resolve keystore error")}
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, unwrapEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -71,7 +70,7 @@ func TestUnwrapHandler(t *testing.T) {
 		svc := mockKMSService()
 		svc.ResolveKeystoreValue = &keystore.MockKeystore{GetKeyHandleErr: errors.New("get key handle error")}
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, unwrapEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -85,7 +84,7 @@ func TestUnwrapHandler(t *testing.T) {
 		svc := mockKMSService()
 		svc.UnwrapError = errors.New("unwrap key error")
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, unwrapEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -120,7 +119,7 @@ func TestUnwrapHandler_BadRequestEncoding(t *testing.T) {
 			srv := &mockkms.MockService{}
 			srv.WrapValue = &crypto.RecipientWrappedKey{}
 
-			op := operation.New(newConfig(withKMSService(srv)))
+			op := newOperation(t, newConfig(withKMSService(srv)))
 			handler := getHandler(t, op, unwrapEndpoint, http.MethodPost)
 
 			rr := httptest.NewRecorder()

--- a/pkg/restapi/kms/operation/operations_wrap_test.go
+++ b/pkg/restapi/kms/operation/operations_wrap_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	mockkms "github.com/trustbloc/hub-kms/pkg/internal/mock/kms"
-	"github.com/trustbloc/hub-kms/pkg/restapi/kms/operation"
 )
 
 func TestWrapHandler(t *testing.T) {
@@ -29,7 +28,7 @@ func TestWrapHandler(t *testing.T) {
 		srv := mockKMSService()
 		srv.WrapValue = &crypto.RecipientWrappedKey{}
 
-		op := operation.New(newConfig(withKMSService(srv)))
+		op := newOperation(t, newConfig(withKMSService(srv)))
 		handler := getHandler(t, op, wrapEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -43,7 +42,7 @@ func TestWrapHandler(t *testing.T) {
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "", bytes.NewBuffer([]byte("")))
 		require.NoError(t, err)
 
-		op := operation.New(newConfig())
+		op := newOperation(t, newConfig())
 		handler := getHandler(t, op, wrapEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -57,7 +56,7 @@ func TestWrapHandler(t *testing.T) {
 		svc := mockKMSService()
 		svc.WrapError = errors.New("wrap key error")
 
-		op := operation.New(newConfig(withKMSService(svc)))
+		op := newOperation(t, newConfig(withKMSService(svc)))
 		handler := getHandler(t, op, wrapEndpoint, http.MethodPost)
 
 		rr := httptest.NewRecorder()
@@ -90,7 +89,7 @@ func TestWrapHandler_BadRequestEncoding(t *testing.T) {
 			srv := &mockkms.MockService{}
 			srv.WrapValue = &crypto.RecipientWrappedKey{}
 
-			op := operation.New(newConfig(withKMSService(srv)))
+			op := newOperation(t, newConfig(withKMSService(srv)))
 			handler := getHandler(t, op, wrapEndpoint, http.MethodPost)
 
 			rr := httptest.NewRecorder()

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/igor-pavlenko/httpsignatures-go v0.0.21
 	github.com/rs/xid v1.2.1
 	github.com/teserakt-io/golang-ed25519 v0.0.0-20200315192543-8255be791ce4
-	github.com/trustbloc/edge-core v0.1.5
+	github.com/trustbloc/edge-core v0.1.6-0.20210121114552-763e3f878b45
 	github.com/trustbloc/edv v0.1.5
 	github.com/trustbloc/hub-auth v0.1.5 // indirect
 	github.com/trustbloc/hub-auth/test/bdd v0.0.0-20201208022224-413a3517d5d5

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -1004,6 +1004,8 @@ github.com/trustbloc/edge-core v0.1.5-0.20201126210935-53388acb41fc h1:sGjZhZKuO
 github.com/trustbloc/edge-core v0.1.5-0.20201126210935-53388acb41fc/go.mod h1:iOoeeW5Jd6/hhEwaK0+lhBstV7yBWzJxckNU21V0+Vg=
 github.com/trustbloc/edge-core v0.1.5 h1:NWXBBZLjaFUi+fB/1nYfLmzip4VFLJ1b8saN1w7rj4M=
 github.com/trustbloc/edge-core v0.1.5/go.mod h1:YnXB2tOVOcW+zK5Xs9RZLhWSGujUzSeZUXrwDOouPgA=
+github.com/trustbloc/edge-core v0.1.6-0.20210121114552-763e3f878b45 h1:Ie+4nJYQLs1Xrm3AOEXPlHpiHa88YV04PidlZYm5gYY=
+github.com/trustbloc/edge-core v0.1.6-0.20210121114552-763e3f878b45/go.mod h1:YnXB2tOVOcW+zK5Xs9RZLhWSGujUzSeZUXrwDOouPgA=
 github.com/trustbloc/edv v0.1.5 h1:0H55CI+3D+zlUi3Y4XJotqAVhf0rT1UURjDgKIr2b+k=
 github.com/trustbloc/edv v0.1.5/go.mod h1:ddp0mjkMZc5gfkVDYvzXTcKuxDT19gT7tl+cbt9S3Hs=
 github.com/trustbloc/hub-auth v0.0.0-20201116135852-764f60b8417b h1:zV0pvpiX/mpdTbjcNas4ICVKid6XU2Zqs4V5+Ibu5sM=


### PR DESCRIPTION
This PR adds support for context caching for LD document loader. This improves performance of onboarding flow by 30-40%.

part of #146

Signed-off-by: Andriy Holovko <andriy.holovko@gmail.com>