### PR TITLE
feat: shamir lock cache, proper env set for stress tests

### DIFF
--- a/cmd/kms-server/startcmd/start.go
+++ b/cmd/kms-server/startcmd/start.go
@@ -49,6 +49,7 @@ import (
 	tlsutil "github.com/trustbloc/edge-core/pkg/utils/tls"
 	"github.com/trustbloc/edge-core/pkg/zcapld"
 
+	"github.com/trustbloc/kms/pkg/controller/cache"
 	"github.com/trustbloc/kms/pkg/controller/command"
 	"github.com/trustbloc/kms/pkg/controller/mw"
 	"github.com/trustbloc/kms/pkg/controller/rest"
@@ -180,6 +181,7 @@ func startServer(srv server, params *serverParameters) error { //nolint:funlen
 		MainKeyType:             kms.AES256GCMType,
 		EDVRecipientKeyType:     kms.NISTP256ECDHKW,
 		EDVMACKeyType:           kms.HMACSHA256Tag256,
+		KeystoreCache:           cache.NewSecureCache(params.cacheExpiration),
 	})
 	if err != nil {
 		return fmt.Errorf("create command: %w", err)

--- a/pkg/controller/cache/secure_cache.go
+++ b/pkg/controller/cache/secure_cache.go
@@ -1,0 +1,85 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cache
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+type cacheSecureItem struct {
+	instance   interface{}
+	bcryptHash []byte
+	createdAt  time.Time
+	mu         sync.Mutex
+}
+
+type createItemFunc = func() (interface{}, error)
+
+// SecureCache is a cache that protected items with password.
+type SecureCache interface {
+	Get(id string, password []byte, createItem createItemFunc) (interface{}, error)
+}
+
+type secureCache struct {
+	items           sync.Map
+	cacheExpiration time.Duration
+}
+
+// NewSecureCache creates SecureCache instance.
+func NewSecureCache(cacheExpiration time.Duration) SecureCache {
+	return &secureCache{
+		items:           sync.Map{},
+		cacheExpiration: cacheExpiration,
+	}
+}
+
+func (k *secureCache) Get(
+	id string, password []byte, createItem createItemFunc) (interface{}, error) {
+	if k.cacheExpiration == 0 {
+		return createItem()
+	}
+
+	item, _ := k.items.LoadOrStore(id, &cacheSecureItem{})
+
+	cacheItem, ok := item.(*cacheSecureItem)
+	if !ok {
+		return nil, errors.New("fail to cast item to cacheSecureItem type")
+	}
+
+	cacheItem.mu.Lock()
+	defer cacheItem.mu.Unlock()
+
+	now := time.Now()
+
+	if cacheItem.instance != nil && now.Sub(cacheItem.createdAt) < k.cacheExpiration {
+		err := bcrypt.CompareHashAndPassword(cacheItem.bcryptHash, password)
+		if err == nil {
+			return cacheItem.instance, nil
+		}
+	}
+
+	bcryptHash, err := bcrypt.GenerateFromPassword(password, bcrypt.MinCost)
+	if err != nil {
+		return nil, fmt.Errorf("get bcrypt failed: %w", err)
+	}
+
+	instance, err := createItem()
+	if err != nil {
+		return nil, fmt.Errorf("createItem failed: %w", err)
+	}
+
+	cacheItem.instance = instance
+	cacheItem.bcryptHash = bcryptHash
+	cacheItem.createdAt = now
+
+	return instance, nil
+}

--- a/pkg/controller/cache/secure_cache_test.go
+++ b/pkg/controller/cache/secure_cache_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cache_test
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hyperledger/aries-framework-go/pkg/mock/secretlock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/kms/pkg/controller/cache"
+)
+
+func TestSecureCache(t *testing.T) {
+	t.Run("Error on create", func(t *testing.T) {
+		slCache := cache.NewSecureCache(time.Second * 10)
+
+		_, err := slCache.Get("user1", []byte("secret share1"), func() (interface{}, error) {
+			return nil, errors.New("create error")
+		})
+
+		require.EqualError(t, err, "createItem failed: create error")
+	})
+
+	t.Run("Get twice same", func(t *testing.T) {
+		ksCache := cache.NewSecureCache(time.Second * 10)
+
+		ks1, err := ksCache.Get("user1", []byte("secret share1"), createMockSecretLock)
+		require.NoError(t, err)
+
+		ks2, err := ksCache.Get("user1", []byte("secret share1"), createMockSecretLock)
+		require.NoError(t, err)
+
+		require.Same(t, ks1, ks2)
+	})
+
+	t.Run("Get twice (wrong share)", func(t *testing.T) {
+		ksCache := cache.NewSecureCache(time.Second * 10)
+
+		ks1, err := ksCache.Get("user1", []byte("secret share1"), createMockSecretLock)
+		require.NoError(t, err)
+
+		ks2, err := ksCache.Get("user1", []byte("secret share2"), createMockSecretLock)
+		require.NoError(t, err)
+
+		require.NotSame(t, ks1, ks2)
+	})
+
+	t.Run("Get twice (diff users)", func(t *testing.T) {
+		ksCache := cache.NewSecureCache(time.Second * 10)
+
+		ks1, err := ksCache.Get("user1", []byte("secret share1"), createMockSecretLock)
+		require.NoError(t, err)
+
+		ks2, err := ksCache.Get("user2", []byte("secret share1"), createMockSecretLock)
+		require.NoError(t, err)
+
+		require.NotSame(t, ks1, ks2)
+	})
+
+	t.Run("Get twice (time out expired)", func(t *testing.T) {
+		ksCache := cache.NewSecureCache(0)
+
+		ks1, err := ksCache.Get("user1", []byte("secret share1"), createMockSecretLock)
+		require.NoError(t, err)
+
+		ks2, err := ksCache.Get("user1", []byte("secret share1"), createMockSecretLock)
+		require.NoError(t, err)
+
+		require.NotSame(t, ks1, ks2)
+	})
+
+	t.Run("Get in parallel", func(t *testing.T) {
+		ksCache := cache.NewSecureCache(time.Hour * 100)
+
+		const groupsNum = 10
+		const itemsInGroupNum = 100
+
+		getGoroutine := &getItemGoroutine{
+			ksCache: ksCache,
+			t:       t,
+			ch:      make(chan interface{}, groupsNum*itemsInGroupNum),
+			wg:      &sync.WaitGroup{},
+		}
+
+		for g := 0; g < groupsNum; g++ {
+			for i := 0; i < itemsInGroupNum; i++ {
+				getGoroutine.wg.Add(1)
+				go getGoroutine.getItem(g)
+			}
+		}
+
+		getGoroutine.wg.Wait()
+		close(getGoroutine.ch)
+
+		ksMap := make(map[interface{}]int)
+		for ks := range getGoroutine.ch {
+			ksMap[ks]++
+		}
+
+		require.Equal(t, groupsNum, len(ksMap))
+
+		for _, v := range ksMap {
+			require.Equal(t, itemsInGroupNum, v)
+		}
+	})
+}
+
+func createMockSecretLock() (interface{}, error) {
+	return &secretlock.MockSecretLock{}, nil
+}
+
+type getItemGoroutine struct {
+	ksCache cache.SecureCache
+	t       *testing.T
+	ch      chan interface{}
+	wg      *sync.WaitGroup
+}
+
+func (g *getItemGoroutine) getItem(group int) {
+	ks1, err := g.ksCache.Get(fmt.Sprintf("user%d", group), []byte("secret share1"), createMockSecretLock)
+	require.NoError(g.t, err)
+
+	g.ch <- ks1
+	g.wg.Done()
+}

--- a/test/bdd/features/kms_stress.feature
+++ b/test/bdd/features/kms_stress.feature
@@ -17,6 +17,6 @@ Feature: KMS stress test
 
   Scenario: Stress test sign and verify methods
     Given "USER_NUMS" users has created a keystore with "ED25519" key using "KMS_STRESS_CONCURRENT_REQ" concurrent requests
-    When  "USER_NUMS" users makes an HTTP POST to "https://localhost:4466/v1/keystores/{keystoreID}/keys/{keyID}/sign" to sign and verify "KMS_STRESS_TIMES" times using "KMS_STRESS_CONCURRENT_REQ" concurrent requests
+    When  "USER_NUMS" users makes an HTTP POST to "https://localhost:4466/v1/keystores/{keystoreID}/keys/{keyID}" to sign and verify "KMS_STRESS_TIMES" times using "KMS_STRESS_CONCURRENT_REQ" concurrent requests
 
 

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -128,6 +128,7 @@ services:
     depends_on:
       - mongodb.example.com
       - edv.trustbloc.local
+      - latency-sim.trustbloc.local
     networks:
       - bdd_net
 
@@ -168,6 +169,22 @@ services:
     volumes:
       - ./oathkeeper-config/ops-keyserver:/oathkeeper
       - ./keys/tls:/etc/tls
+    networks:
+      - bdd_net
+
+  latency-sim.trustbloc.local:
+    container_name: latency-sim.trustbloc.local
+    build: ./latency-sim-config
+    cap_add:
+      - NET_ADMIN
+    ports:
+      - 8082:8082
+      - 8071:8071
+    volumes:
+      - ./keys/tls:/etc/nginx/certs
+      - ./latency-sim-config/nginx.conf:/etc/nginx/nginx.conf
+    depends_on:
+      - edv.trustbloc.local
     networks:
       - bdd_net
 

--- a/test/bdd/fixtures/latency-sim-config/Dockerfile
+++ b/test/bdd/fixtures/latency-sim-config/Dockerfile
@@ -1,0 +1,11 @@
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+FROM nginx:latest
+RUN apt-get update && \
+    apt-get install iproute2 -y
+
+CMD nginx -g daemon off;

--- a/test/bdd/fixtures/latency-sim-config/nginx.conf
+++ b/test/bdd/fixtures/latency-sim-config/nginx.conf
@@ -1,0 +1,41 @@
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+events {}
+
+http {
+    upstream edv {
+        server edv.trustbloc.local:8081;
+    }
+
+    upstream hub {
+        server hub-auth.trustbloc.local:8070;
+    }
+
+    server {
+        listen 8082 ssl;
+
+        ssl_certificate /etc/nginx/certs/ec-pubCert.pem;
+        ssl_certificate_key /etc/nginx/certs/ec-key.pem;
+        ssl_protocols TLSv1.2 TLSv1.3;
+
+        location / {
+            proxy_pass https://edv;
+        }
+    }
+
+    server {
+        listen 8071 ssl;
+
+        ssl_certificate /etc/nginx/certs/ec-pubCert.pem;
+        ssl_certificate_key /etc/nginx/certs/ec-key.pem;
+        ssl_protocols TLSv1.2 TLSv1.3;
+
+        location / {
+            proxy_pass https://hub;
+        }
+    }
+}

--- a/test/bdd/pkg/internal/bddutil/workerpool.go
+++ b/test/bdd/pkg/internal/bddutil/workerpool.go
@@ -69,7 +69,7 @@ func (p *WorkerPool) Start() {
 }
 
 // Stop stops the workers in the pool and stops listening for responses
-func (p *WorkerPool) Stop() {
+func (p *WorkerPool) Stop() error {
 	close(p.reqChan)
 
 	p.logger.Infof("Waiting %d for workers to finish...", len(p.workers))
@@ -85,6 +85,14 @@ func (p *WorkerPool) Stop() {
 	p.wgResp.Wait()
 
 	p.logger.Infof("... listener finished.")
+
+	for _, resp := range p.responses {
+		if resp.Err != nil {
+			return resp.Err
+		}
+	}
+
+	return nil
 }
 
 // Submit submits a request for processing

--- a/test/bdd/pkg/kms/models.go
+++ b/test/bdd/pkg/kms/models.go
@@ -127,7 +127,7 @@ type setSecretRequest struct {
 }
 
 type errorResponse struct {
-	Message string `json:"errMessage,omitempty"`
+	Message string `json:"message,omitempty"`
 }
 
 type easyReq struct {

--- a/test/bdd/pkg/kms/stress_steps.go
+++ b/test/bdd/pkg/kms/stress_steps.go
@@ -18,6 +18,8 @@ import (
 const userNameTplt = "User%d"
 
 func (s *Steps) storeSecretInHubAuthForMultipleUsers(usersNumberEnv string) error {
+	createStart := time.Now()
+
 	usersNumber, err := getUsersNumber(usersNumberEnv)
 	if err != nil {
 		return err
@@ -30,10 +32,13 @@ func (s *Steps) storeSecretInHubAuthForMultipleUsers(usersNumberEnv string) erro
 		}
 	}
 
+	fmt.Printf("store secret on Hub Auth for %d wallets took: %s\n", usersNumber, time.Since(createStart).String())
 	return nil
 }
 
 func (s *Steps) createEDVDataVaultForMultipleUsers(usersNumberEnv string) error {
+	createStart := time.Now()
+
 	usersNumber, err := getUsersNumber(usersNumberEnv)
 	if err != nil {
 		return err
@@ -46,6 +51,7 @@ func (s *Steps) createEDVDataVaultForMultipleUsers(usersNumberEnv string) error 
 		}
 	}
 
+	fmt.Printf("Create %d data vaults on EDV took: %s\n", usersNumber, time.Since(createStart).String())
 	return nil
 }
 
@@ -74,7 +80,10 @@ func (s *Steps) createKeystoreForMultipleUsers(usersNumberEnv, keyType, concurre
 		})
 	}
 
-	createPool.Stop()
+	err = createPool.Stop()
+	if err != nil {
+		return err
+	}
 
 	createTimeStr := time.Since(createStart).String()
 
@@ -117,7 +126,10 @@ func (s *Steps) makeSignVerifyMultipleTimeForMultipleUsers(
 		})
 	}
 
-	createPool.Stop()
+	err = createPool.Stop()
+	if err != nil {
+		return err
+	}
 
 	createTimeStr := time.Since(createStart).String()
 
@@ -175,12 +187,12 @@ type signVerifyRequest struct {
 func (r *signVerifyRequest) Invoke() (interface{}, error) {
 	message := "test message"
 	for i := 0; i < r.times; i++ {
-		err := r.steps.makeSignMessageReq(r.userName, r.endpoint, message)
+		err := r.steps.makeSignMessageReq(r.userName, r.endpoint+"/sign", message)
 		if err != nil {
 			return nil, err
 		}
 
-		err = r.steps.makeVerifySignatureReq(r.userName, r.endpoint, "signature", message)
+		err = r.steps.makeVerifySignatureReq(r.userName, r.endpoint+"/verify", "signature", message)
 		if err != nil {
 			return nil, err
 		}

--- a/test/bdd/pkg/kms/user.go
+++ b/test/bdd/pkg/kms/user.go
@@ -159,7 +159,7 @@ func (u *user) processResponse(parsedResp interface{}, resp *http.Response) erro
 			"errMessage": errResp.Message,
 		}
 
-		return fmt.Errorf("response status: %s", resp.Status)
+		return fmt.Errorf("response status: [%s, %s]", resp.Status, errResp.Message)
 	}
 
 	if parsedResp == nil {


### PR DESCRIPTION
### Stress tests results:

**Without secretlock cache. 200ms network delay on hub-auth.trustbloc.local**
Create 10 data vaults on EDV took: 25.991446457s
Created key stores 10 took: 2.788173368s
 50 sign/verify requests took: 10.439802036s

**With secretlock cache. 200ms network delay on hub-auth.trustbloc.local**
Create 10 data vaults on EDV took: 18.101700334s
Created key stores 10 took: 407.51765ms
50 sign/verify requests took: 658.046203ms


Signed-off-by: Volodymyr Kubiv <volodymyr.kubiv@euristiq.com>