### PR TITLE
fix: disallow noop secret lock

### DIFF
--- a/cmd/kms-server/startcmd/params.go
+++ b/cmd/kms-server/startcmd/params.go
@@ -364,7 +364,7 @@ func createFlags(startCmd *cobra.Command) {
 	startCmd.Flags().String(enableCacheFlagName, "false", enableCacheFlagUsage)
 	startCmd.Flags().String(enableZCAPsFlagName, "false", enableZCAPsFlagUsage)
 	startCmd.Flags().String(enableCORSFlagName, "false", enableCORSFlagUsage)
-	startCmd.Flags().String(logLevelFlagName, "", logLevelFlagUsage)
+	startCmd.Flags().String(logLevelFlagName, "info", logLevelFlagUsage)
 	startCmd.Flags().String(secretLockTypeFlagName, "", secretLockTypeFlagUsage)
 	startCmd.Flags().String(secretLockKeyPathFlagName, "", secretLockKeyPathFlagUsage)
 	startCmd.Flags().String(secretLockAWSKeyURIFlagName, "", secretLockAWSKeyURIFlagUsage)

--- a/cmd/kms-server/startcmd/start.go
+++ b/cmd/kms-server/startcmd/start.go
@@ -35,7 +35,6 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/secretlock"
 	"github.com/hyperledger/aries-framework-go/pkg/secretlock/local"
 	"github.com/hyperledger/aries-framework-go/pkg/secretlock/local/masterlock/hkdf"
-	"github.com/hyperledger/aries-framework-go/pkg/secretlock/noop"
 	ldstore "github.com/hyperledger/aries-framework-go/pkg/store/ld"
 	"github.com/hyperledger/aries-framework-go/pkg/vdr"
 	vdrkey "github.com/hyperledger/aries-framework-go/pkg/vdr/key"
@@ -401,7 +400,7 @@ func createAwsSecretLock(parameters *secretLockParameters) (secretlock.Service, 
 
 func createLocalSecretLock(keyPath string) (secretlock.Service, error) {
 	if keyPath == "" {
-		return &noop.NoLock{}, nil
+		return nil, fmt.Errorf("no key defined for local secret lock")
 	}
 
 	primaryKeyReader, err := local.MasterKeyFromPath(keyPath)


### PR DESCRIPTION
Noop secret lock leads to unprotected keys in the underlying storage. It's a security risk. This PR removes support for that type of secret lock.

Signed-off-by: Andrii Holovko <andriy.holovko@gmail.com>