### PR TITLE
fix: GNAP header inspection bug

### DIFF
--- a/pkg/controller/mw/authmw/zcapmw/zcap_middleware.go
+++ b/pkg/controller/mw/authmw/zcapmw/zcap_middleware.go
@@ -62,9 +62,9 @@ type Middleware struct {
 
 // Accept checks if middleware can handle auth for the given request.
 func (mw *Middleware) Accept(req *http.Request) bool {
-	_, ok := req.Header["Capability-Invocation"]
+	headerValues := req.Header.Values("Capability-Invocation")
 
-	return ok
+	return len(headerValues) > 0
 }
 
 // Middleware returns middleware func.


### PR DESCRIPTION
The GNAP middleware's Accept method checks each value in the Authorization header slice and if any of them contain a GNAP token, then the middleware handles it. However, the middleware Handle method then uses the Header.Get method, which always gets the first value from the Header slice. Thus, if a request comes in with a GNAP token in the Authorization header but in any value but the first, the handler will accept it but then fail to handle it since it will miss the token.

Also updated code that access headers to use the built-in Header methods to retrieve the values (instead of directly accessing the map) since they ensure that values are canonicalized.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>