### PR TITLE
fix: Linter error

### DIFF
--- a/pkg/controller/mw/authmw/gnapmw/gnap_middleware_test.go
+++ b/pkg/controller/mw/authmw/gnapmw/gnap_middleware_test.go
@@ -206,7 +206,7 @@ func TestMiddleware(t *testing.T) {
 		next := NewMockHTTPHandler(ctrl)
 		next.EXPECT().ServeHTTP(gomock.Any(), gomock.Any()).Times(1)
 
-		req, err := http.NewRequestWithContext(context.Background(), "", "", nil)
+		req, err := http.NewRequestWithContext(context.Background(), "", "", http.NoBody)
 		require.NoError(t, err)
 
 		req.Header.Add("Authorization", "Some other token")


### PR DESCRIPTION
Updated a line in one of the unit-tests to use http.NoBody instead of nil.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>