### PR TITLE
feat: CL Anoncreds Remote KMS/Crypto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage.out
 test/bdd/fixtures/keys
 openAPI.yml
 .build/*
+bin/

--- a/cmd/kms-server/go.mod
+++ b/cmd/kms-server/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/dgraph-io/ristretto v0.1.0
 	github.com/google/tink/go v1.6.1
 	github.com/gorilla/mux v1.8.0
-	github.com/hyperledger/aries-framework-go v0.1.9-0.20220818134654-5e75e60870c9
+	github.com/hyperledger/aries-framework-go v0.1.9-0.20220822173318-77fbef728d02
 	github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20220428163625-96d8261511e1
 	github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220615170242-cda5092b4faf
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/orb v1.0.0-rc2.0.20220811162145-47649b185a56

--- a/cmd/kms-server/go.sum
+++ b/cmd/kms-server/go.sum
@@ -678,8 +678,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huandu/xstrings v1.0.0/go.mod h1:4qWG/gcEcfX4z/mBDHJ++3ReCw9ibxbsNJbcucJdbSo=
 github.com/huandu/xstrings v1.2.0/go.mod h1:DvyZB1rfVYsBIigL8HwpZgxHwXozlTgGqn63UyNX5k4=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
-github.com/hyperledger/aries-framework-go v0.1.9-0.20220818134654-5e75e60870c9 h1:mJzmmZeaJRodCFbEnftVMZPZXovGsBq8H90JfuifDQk=
-github.com/hyperledger/aries-framework-go v0.1.9-0.20220818134654-5e75e60870c9/go.mod h1:28aD9QTgVjeAl86vHNFwkOYwQwZiTrrODMpjE2PYz3M=
+github.com/hyperledger/aries-framework-go v0.1.9-0.20220822173318-77fbef728d02 h1:phipjA38PzjN7/h6t+8Vv8XPlW5t+327GD0p9v8wx4Y=
+github.com/hyperledger/aries-framework-go v0.1.9-0.20220822173318-77fbef728d02/go.mod h1:28aD9QTgVjeAl86vHNFwkOYwQwZiTrrODMpjE2PYz3M=
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20220428163625-96d8261511e1 h1:J17kEzMu0cA2xsgC0VcZiKu9ivV0/WMMmeCW7UrfQ1Y=
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20220428163625-96d8261511e1/go.mod h1:q8qjsQpYo7AYG0pqQg1zgEoIVc+Hrpf5S0WciiwPDQA=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220615170242-cda5092b4faf h1:F12zbOSRsye3IWK3Zb6prgrqQQFYnz5zjGSCh9pfYzk=

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/google/tink/go v1.6.1
 	github.com/gorilla/mux v1.8.0
-	github.com/hyperledger/aries-framework-go v0.1.9-0.20220818134654-5e75e60870c9
+	github.com/hyperledger/aries-framework-go v0.1.9-0.20220822173318-77fbef728d02
 	github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20220610133818-119077b0ec85
 	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220610133818-119077b0ec85
 	github.com/hyperledger/aries-framework-go/spi v0.0.0-20220610133818-119077b0ec85

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,8 @@ github.com/hashicorp/vault/sdk v0.1.13/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvh
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/hyperledger/aries-framework-go v0.1.9-0.20220818134654-5e75e60870c9 h1:mJzmmZeaJRodCFbEnftVMZPZXovGsBq8H90JfuifDQk=
-github.com/hyperledger/aries-framework-go v0.1.9-0.20220818134654-5e75e60870c9/go.mod h1:28aD9QTgVjeAl86vHNFwkOYwQwZiTrrODMpjE2PYz3M=
+github.com/hyperledger/aries-framework-go v0.1.9-0.20220822173318-77fbef728d02 h1:phipjA38PzjN7/h6t+8Vv8XPlW5t+327GD0p9v8wx4Y=
+github.com/hyperledger/aries-framework-go v0.1.9-0.20220822173318-77fbef728d02/go.mod h1:28aD9QTgVjeAl86vHNFwkOYwQwZiTrrODMpjE2PYz3M=
 github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20220610133818-119077b0ec85 h1:YWww6rlXZprOnBP3LD8RAzbkszmplnLvabtlBZtzLTA=
 github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20220610133818-119077b0ec85/go.mod h1:JrwivOOQmuXbV1mFWgBGWnfCorOFdfGkpBsYK8dYrfM=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220610133818-119077b0ec85 h1:P82lZe6zDjaP2j87nDYQBSBYrB6Nq6nc9MtyNMC3K4A=

--- a/pkg/controller/command/actions.go
+++ b/pkg/controller/command/actions.go
@@ -8,28 +8,31 @@ package command
 
 // List of actions supported by KMS.
 const (
-	ActionCreateDID       = "createDID"
-	ActionCreateKeyStore  = "createKeyStore"
-	ActionCreateKey       = "createKey"
-	ActionImportKey       = "importKey"
-	ActionExportKey       = "exportKey"
-	ActionRotateKey       = "rotateKey"
-	ActionSign            = "sign"
-	ActionVerify          = "verify"
-	ActionEncrypt         = "encrypt"
-	ActionDecrypt         = "decrypt"
-	ActionComputeMac      = "computeMAC"
-	ActionVerifyMAC       = "verifyMAC"
-	ActionSignMulti       = "signMulti"
-	ActionVerifyMulti     = "verifyMulti"
-	ActionDeriveProof     = "deriveProof"
-	ActionVerifyProof     = "verifyProof"
-	ActionEasy            = "easy"
-	ActionEasyOpen        = "easyOpen"
-	ActionSealOpen        = "sealOpen"
-	ActionWrap            = "wrap"
-	ActionUnwrap          = "unwrap"
-	ActionStoreCapability = "updateEDVCapability"
+	ActionCreateDID        = "createDID"
+	ActionCreateKeyStore   = "createKeyStore"
+	ActionCreateKey        = "createKey"
+	ActionImportKey        = "importKey"
+	ActionExportKey        = "exportKey"
+	ActionRotateKey        = "rotateKey"
+	ActionSign             = "sign"
+	ActionVerify           = "verify"
+	ActionEncrypt          = "encrypt"
+	ActionDecrypt          = "decrypt"
+	ActionComputeMac       = "computeMAC"
+	ActionVerifyMAC        = "verifyMAC"
+	ActionSignMulti        = "signMulti"
+	ActionVerifyMulti      = "verifyMulti"
+	ActionDeriveProof      = "deriveProof"
+	ActionVerifyProof      = "verifyProof"
+	ActionEasy             = "easy"
+	ActionEasyOpen         = "easyOpen"
+	ActionSealOpen         = "sealOpen"
+	ActionWrap             = "wrap"
+	ActionUnwrap           = "unwrap"
+	ActionBlind            = "blind"
+	ActionCorrectnessProof = "correctnessProof"
+	ActionSignWithSecrets  = "signWithSecrets"
+	ActionStoreCapability  = "updateEDVCapability"
 )
 
 func allActions() []string {
@@ -53,6 +56,9 @@ func allActions() []string {
 		ActionVerifyProof,
 		ActionWrap,
 		ActionUnwrap,
+		ActionBlind,
+		ActionCorrectnessProof,
+		ActionSignWithSecrets,
 		ActionStoreCapability,
 	}
 }

--- a/pkg/controller/command/models.go
+++ b/pkg/controller/command/models.go
@@ -59,6 +59,7 @@ type CreateKeyStoreResponse struct {
 // CreateKeyRequest is a request to create a key.
 type CreateKeyRequest struct {
 	KeyType kms.KeyType `json:"key_type"`
+	Attrs   []string    `json:"attrs,omitempty"`
 }
 
 // CreateKeyResponse is a response for CreateKey request.
@@ -82,6 +83,7 @@ type ImportKeyResponse struct {
 // RotateKeyRequest is a request to rotate a key.
 type RotateKeyRequest struct {
 	KeyType kms.KeyType `json:"key_type"`
+	Attrs   []string    `json:"attrs,omitempty"`
 }
 
 // RotateKeyResponse is a response for RotateKeyRequest request.
@@ -247,4 +249,34 @@ type UnwrapKeyRequest struct {
 // UnwrapKeyResponse is a response for UnwrapKey request.
 type UnwrapKeyResponse struct {
 	Key []byte `json:"key"`
+}
+
+// BlindRequest is a serializable Blind request.
+type BlindRequest struct {
+	Values []map[string]interface{} `json:"values,omitempty"`
+}
+
+// BlindResponse is a serializable Blind response.
+type BlindResponse struct {
+	Blinded [][]byte `json:"blinded"`
+}
+
+// CorrectnessProofResponse is a serializable GetCorrectnessProof response.
+type CorrectnessProofResponse struct {
+	CorrectnessProof []byte `json:"correctness_proof"`
+}
+
+// SignWithSecretsRequest is a serializable SignWithSecrets request.
+type SignWithSecretsRequest struct {
+	Values           map[string]interface{} `json:"values"`
+	Secrets          []byte                 `json:"secrets"`
+	CorrectnessProof []byte                 `json:"correctness_proof"`
+	Nonces           [][]byte               `json:"nonces"`
+	DID              string                 `json:"did"`
+}
+
+// SignWithSecretsResponse is a serializable SignWithSecrets response.
+type SignWithSecretsResponse struct {
+	Signature        []byte `json:"signature"`
+	CorrectnessProof []byte `json:"correctness_proof"`
 }

--- a/pkg/controller/rest/models.go
+++ b/pkg/controller/rest/models.go
@@ -85,6 +85,9 @@ type createKeyReq struct { //nolint:unused,deadcode
 		// A type of key to create. Check https://github.com/hyperledger/aries-framework-go/blob/main/pkg/kms/api.go
 		// for supported key types.
 		KeyType string `json:"key_type"`
+		// Any extra attributes necessary for a key creation. Optional.
+		// required: false
+		Attrs []string `json:"attrs,omitempty"`
 	}
 }
 
@@ -188,6 +191,9 @@ type rotateKeyReq struct { //nolint:unused,deadcode
 		// A type on new key.
 		// required: true
 		KeyType string `json:"key_type"`
+		// Any extra attributes necessary for a key creation. Optional.
+		// required: false
+		Attrs []string `json:"attrs,omitempty"`
 	}
 }
 
@@ -854,6 +860,117 @@ type unwrapKeyResp struct { //nolint:unused,deadcode
 	Body struct {
 		// A base64-encoded unwrapped key.
 		Key string `json:"key"`
+	}
+}
+
+// blindReq model
+//
+// swagger:parameters blindReq
+type blindReq struct { //nolint:unused,deadcode
+	// The key store's ID.
+	//
+	// in: path
+	// required: true
+	KeyStoreID string `json:"key_store_id"`
+
+	// The key's ID.
+	//
+	// in: path
+	// required: true
+	KeyID string `json:"key_id"`
+
+	// in: body
+	Body struct {
+		// Values to blind.
+		Values []map[string]interface{} `json:"values,omitempty"`
+	}
+}
+
+// blindResp model
+//
+// swagger:response blindResp
+type blindResp struct { //nolint:unused,deadcode
+	// in: body
+	Body struct {
+		// Blinded values.
+		Blinded [][]byte `json:"blinded"`
+	}
+}
+
+// correctnessProofReq model
+//
+// swagger:parameters correctnessProofReq
+type correctnessProofReq struct { //nolint:unused,deadcode
+	// The key store's ID.
+	//
+	// in: path
+	// required: true
+	KeyStoreID string `json:"key_store_id"`
+
+	// The key's ID.
+	//
+	// in: path
+	// required: true
+	KeyID string `json:"key_id"`
+}
+
+// correctnessProofResp model
+//
+// swagger:response correctnessProofResp
+type correctnessProofResp struct { //nolint:unused,deadcode
+	// in: body
+	Body struct {
+		// Correctness proof for a CredDef key.
+		CorrectnessProof []byte `json:"correctness_proof"`
+	}
+}
+
+// signWithSecretsReq model
+//
+// swagger:parameters signWithSecretsReq
+type signWithSecretsReq struct { //nolint:unused,deadcode
+	// The key store's ID.
+	//
+	// in: path
+	// required: true
+	KeyStoreID string `json:"key_store_id"`
+
+	// The key's ID.
+	//
+	// in: path
+	// required: true
+	KeyID string `json:"key_id"`
+
+	// in: body
+	Body struct {
+		// Credential Values.
+		Values map[string]interface{} `json:"values"`
+
+		// Blinded secrets.
+		Secrets []byte `json:"secrets"`
+
+		// Blinded secrets correctness proof.
+		CorrectnessProof []byte `json:"correctness_proof"`
+
+		// Nonces (offer and request).
+		Nonces [][]byte `json:"nonces"`
+
+		// DID.
+		DID string `json:"did"`
+	}
+}
+
+// signWithSecretsResp model
+//
+// swagger:response signWithSecretsResp
+type signWithSecretsResp struct { //nolint:unused,deadcode
+	// in: body
+	Body struct {
+		// Credential signature.
+		Signature []byte `json:"signature"`
+
+		// Credential signature's correctness proof.
+		CorrectnessProof []byte `json:"correctness_proof"`
 	}
 }
 

--- a/pkg/kms/cache/wrap_kms.go
+++ b/pkg/kms/cache/wrap_kms.go
@@ -122,7 +122,8 @@ func (w *wrappedKMS) PubKeyBytesToHandle(pubKey []byte, kt arieskms.KeyType,
 }
 
 func (w *wrappedKMS) ImportPrivateKey(privateKey interface{}, kt arieskms.KeyType,
-	opts ...arieskms.PrivateKeyOpts) (string, interface{}, error) {
+	opts ...arieskms.PrivateKeyOpts,
+) (string, interface{}, error) {
 	return w.kms.ImportPrivateKey(privateKey, kt, opts...)
 }
 

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/cucumber/godog v0.10.0
 	github.com/google/uuid v1.3.0
 	github.com/greenpau/go-calculator v1.0.1
-	github.com/hyperledger/aries-framework-go v0.1.9-0.20220818134654-5e75e60870c9
+	github.com/hyperledger/aries-framework-go v0.1.9-0.20220822173318-77fbef728d02
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/orb v1.0.0-rc2.0.20220811162145-47649b185a56
 	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220610133818-119077b0ec85
 	github.com/hyperledger/aries-framework-go/spi v0.0.0-20220614152730-3d817acfa48b

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -624,8 +624,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huandu/xstrings v1.0.0/go.mod h1:4qWG/gcEcfX4z/mBDHJ++3ReCw9ibxbsNJbcucJdbSo=
 github.com/huandu/xstrings v1.2.0/go.mod h1:DvyZB1rfVYsBIigL8HwpZgxHwXozlTgGqn63UyNX5k4=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
-github.com/hyperledger/aries-framework-go v0.1.9-0.20220818134654-5e75e60870c9 h1:mJzmmZeaJRodCFbEnftVMZPZXovGsBq8H90JfuifDQk=
-github.com/hyperledger/aries-framework-go v0.1.9-0.20220818134654-5e75e60870c9/go.mod h1:28aD9QTgVjeAl86vHNFwkOYwQwZiTrrODMpjE2PYz3M=
+github.com/hyperledger/aries-framework-go v0.1.9-0.20220822173318-77fbef728d02 h1:phipjA38PzjN7/h6t+8Vv8XPlW5t+327GD0p9v8wx4Y=
+github.com/hyperledger/aries-framework-go v0.1.9-0.20220822173318-77fbef728d02/go.mod h1:28aD9QTgVjeAl86vHNFwkOYwQwZiTrrODMpjE2PYz3M=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220615170242-cda5092b4faf h1:F12zbOSRsye3IWK3Zb6prgrqQQFYnz5zjGSCh9pfYzk=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220615170242-cda5092b4faf/go.mod h1:GDANCnJONcCqBvv6QgKuk5Y2FWHyD/Hu26kyc7NTyfY=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/orb v1.0.0-rc2.0.20220811162145-47649b185a56 h1:b7BLv+CnYVaBrOgrv0zxUgMeilfrK/Z0Yw/fG4GQbAA=

--- a/test/bdd/pkg/kms/zcap.go
+++ b/test/bdd/pkg/kms/zcap.go
@@ -44,10 +44,6 @@ type authzKMSSigner struct {
 	authzUser *user
 }
 
-func (a *authzKMSSigner) Alg() string {
-	return ""
-}
-
 func newAuthzKMSSigner(s *Steps, authzUser *user) *authzKMSSigner {
 	return &authzKMSSigner{s: s, authzUser: authzUser}
 }
@@ -60,6 +56,10 @@ func (a *authzKMSSigner) Sign(data []byte) ([]byte, error) {
 	}
 
 	return []byte(a.authzUser.data["signature"]), nil
+}
+
+func (a *authzKMSSigner) Alg() string {
+	return ""
 }
 
 type remoteKMS struct {


### PR DESCRIPTION
**Title:**
CL Anoncreds Remote KMS/Crypto (server part)

**Description:**
* Sixth PR to support CL in `af-go` [#180](https://github.com/hyperledger/aries-framework-go/issues/180)
* This PR adds support for KMS extension for remote KMS/Crypto 

**Summary:**
* extended kms api signature with opts
* added CL crypto methods to rest/command
* added unit tests
* updated deps for kms-server/bdd
* updated mocks with latest changes