### PR TITLE
refactor: Add env variable to define supported auth mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ $ ./build/bin/kms-server start --host localhost:8076 --database-type mongodb --d
 | --shamir-secret-cache-ttl    | KMS_SHAMIR_SECRET_CACHE_TTL    | An optional value for Shamir secrets cache TTL. Defaults to 10m if caching is enabled. If set to 0, keys are never cached.                | 
 | --kms-cache-ttl              | KMS_KMS_CACHE_TTL              | An optional value for cache TTL for keys stored in server kms. Defaults to 10m if caching is enabled. If set to 0, keys are never cached. |
 | --enable-cors                | KMS_CORS_ENABLE                | Enables CORS. Possible values: [true] [false]. Defaults to false.                                                                         |
-| --disable-auth               | KMS_AUTH_DISABLE               | Disables authorization. Possible values: [true] [false]. Defaults to false.                                                               |
+| --auth-type                  | KMS_AUTH_TYPE                  | Comma-separated list of the types of authorization to enable. Possible values [GNAP] [ZCAP]. Defaults to 'ZCAP,GNAP'.                     |
 | --log-level                  | KMS_LOG_LEVEL                  | Logging level. Supported options: critical, error, warning, info, debug. Defaults to info.                                                |
 
 ## Running tests

--- a/cmd/kms-server/startcmd/start_test.go
+++ b/cmd/kms-server/startcmd/start_test.go
@@ -512,6 +512,47 @@ func TestStartCmdWithKMSCacheTTLParam(t *testing.T) {
 	})
 }
 
+func TestStartCmdWithAuthTypeParam(t *testing.T) {
+	t.Run("Success with ZCAP and GNAP set", func(t *testing.T) {
+		startCmd, err := Cmd(&mockServer{})
+		require.NoError(t, err)
+
+		args := requiredArgs(storageTypeMemOption)
+		args = append(args, "--"+authTypeFlagName, "ZCAP,GNAP")
+
+		startCmd.SetArgs(args)
+
+		err = startCmd.Execute()
+		require.NoError(t, err)
+	})
+
+	t.Run("Success with none set", func(t *testing.T) {
+		startCmd, err := Cmd(&mockServer{})
+		require.NoError(t, err)
+
+		args := requiredArgs(storageTypeMemOption)
+		args = append(args, "--"+authTypeFlagName, "")
+
+		startCmd.SetArgs(args)
+
+		err = startCmd.Execute()
+		require.NoError(t, err)
+	})
+
+	t.Run("Fail with unknown auth type", func(t *testing.T) {
+		startCmd, err := Cmd(&mockServer{})
+		require.NoError(t, err)
+
+		args := requiredArgs(storageTypeMemOption)
+		args = append(args, "--"+authTypeFlagName, "some-unknown-auth-type")
+
+		startCmd.SetArgs(args)
+
+		err = startCmd.Execute()
+		require.Error(t, err)
+	})
+}
+
 func TestStartKMSService(t *testing.T) {
 	const invalidStorageOption = "invalid"
 
@@ -620,7 +661,7 @@ func setEnvVars(t *testing.T) {
 	err = os.Setenv(secretLockKeyPathEnvKey, secretLockKeyFile)
 	require.NoError(t, err)
 
-	err = os.Setenv(disableAuthEnvKey, "true")
+	err = os.Setenv(authTypeEnvKey, "")
 	require.NoError(t, err)
 }
 
@@ -639,7 +680,7 @@ func unsetEnvVars(t *testing.T) {
 	err = os.Unsetenv(secretLockKeyPathEnvKey)
 	require.NoError(t, err)
 
-	err = os.Unsetenv(disableAuthEnvKey)
+	err = os.Unsetenv(authTypeEnvKey)
 	require.NoError(t, err)
 }
 

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -115,7 +115,7 @@ services:
       - KMS_DATABASE_TYPE=mongodb
       - KMS_DATABASE_URL=mongodb://mongodb.example.com:27017
       - KMS_DATABASE_PREFIX=orbkms_
-      - KMS_AUTH_DISABLE=true
+      - KMS_AUTH_TYPE=
       - KMS_GNAP_HTTPSIG_DISABLE=false
       - KMS_CACHE_ENABLE=true
       - KMS_LOG_LEVEL=debug


### PR DESCRIPTION
Addresses issue #330 

TODO:
- Add tests to cover the following cases:
  - ZCAP auth only
  - GNAP auth only 
  - No auth specified  
- Restructure kms-server auth mode code to simplify future maintenance   

Signed-off-by: Yevgen Pukhta <eugene.pukhta@gmail.com>